### PR TITLE
support scalable multi-workflows

### DIFF
--- a/orchard/orchard_client.go
+++ b/orchard/orchard_client.go
@@ -55,15 +55,15 @@ func (c OrchardRestClient) Create(wf table.Workflow) ([]string, error) {
 		log.Printf("OrchardRestClient Create > Generate error: %v\n", err)
 		return []string{}, err
 	}
-	orchardIDs := []string{}
+	createdIDs := []string{}
 	for _, result := range results {
-		orchardId, err := c.create(result)
+		orchardID, err := c.create(result)
 		if err != nil {
-			return []string{}, err
+			return createdIDs, err
 		}
-		orchardIDs = append(orchardIDs, orchardId)
+		createdIDs = append(createdIDs, orchardID)
 	}
-	return orchardIDs, nil
+	return createdIDs, nil
 }
 
 func (c OrchardRestClient) create(result string) (string, error) {
@@ -89,6 +89,18 @@ func (c OrchardRestClient) create(result string) (string, error) {
 func (c OrchardRestClient) Activate(orchardID string) error {
 	url := fmt.Sprintf("%s/v1/workflow/%s/activate", c.Host, orchardID)
 	_, err := c.request(http.MethodPut, url, nil)
+	return err
+}
+
+func (c OrchardRestClient) Cancel(orchardID string) error {
+	url := fmt.Sprintf("%s/v1/workflow/%s/cancel", c.Host, orchardID)
+	_, err := c.request(http.MethodPut, url, nil)
+	return err
+}
+
+func (c OrchardRestClient) Delete(orchardID string) error {
+	url := fmt.Sprintf("%s/v1/workflow/%s", c.Host, orchardID)
+	_, err := c.request(http.MethodDelete, url, nil)
 	return err
 }
 

--- a/orchard/orchard_runner.go
+++ b/orchard/orchard_runner.go
@@ -103,20 +103,19 @@ func processCmd(command string, pwd string) ([]string, error) {
 		return []string{}, fmt.Errorf("parse command line error %w", err)
 	}
 	if len(cmds) < 1 {
-		return []string{}, fmt.Errorf("Invalid command line %s", command)
+		return []string{}, fmt.Errorf("invalid command line %s", command)
 	}
 	cmd := exec.Command(cmds[0], cmds[1:]...)
 	stdout, stderr, err := cmdOutput(cmd)
 	output := string(stdout)
-	outputs := []string{}
-	for _, payload := range strings.Split(output, "\n") {
-		if len(payload) > 0 {
-			outputs = append(outputs, payload)
-		}
-	}
 	if err != nil {
 		combinedOutput := fmt.Sprintf("%s\n%s", output, string(stderr))
 		return []string{}, fmt.Errorf("exec command %v has error: %w: %s", command, err, combinedOutput)
+	}
+	var outputs []string
+	err = json.Unmarshal([]byte(output), &outputs)
+	if err != nil {
+		return []string{}, fmt.Errorf("marshall error %w", err)
 	}
 	return outputs, nil
 }

--- a/orchard/orchard_runner.go
+++ b/orchard/orchard_runner.go
@@ -115,7 +115,12 @@ func processCmd(command string, pwd string) ([]string, error) {
 	var outputs []string
 	err = json.Unmarshal([]byte(output), &outputs)
 	if err != nil {
-		return []string{}, fmt.Errorf("marshall error %w", err)
+		fmt.Printf("unmarshall error: %s", err)
+		for _, payload := range strings.Split(output, "\n") {
+			if len(payload) > 0 {
+				outputs = append(outputs, payload)
+			}
+		}
 	}
 	return outputs, nil
 }

--- a/service/control.go
+++ b/service/control.go
@@ -122,6 +122,8 @@ func (ctrl *Control) Run() {
 	if err := r.SetTrustedProxies(ctrl.trustedProxies); err != nil {
 		log.Fatal(err)
 	}
+
+	r.Use(gin.Recovery())
 	r.Use(metrics.GinMiddleware)
 
 	v1 := r.Group("/v1")

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -126,7 +126,6 @@ func (s *Scheduler) createActivateWorkflow(
 		notifyOwner(wf, err)
 		return s.deleteWorkflows(client, createdIDs, statuses)
 	}
-
 	for _, createdID := range createdIDs {
 		err = client.Activate(createdID)
 		if err != nil {

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -88,8 +88,8 @@ func (s *Scheduler) createActivateWorkflow(
 		fmt.Printf("[error] error creating workflow: %s\n", err)
 		notifyOwner(wf, err)
 		for _, createdID := range createdIDs {
-			err = client.Delete(createdID) // delete created workflows
-			if err != nil {
+			// delete created workflows
+			if err := client.Delete(createdID); err != nil {
 				fmt.Printf("[error] error deleting workflow: %s\n", err)
 				scheduleStatus[createdID] = DeleteFailed.ToString()
 			}
@@ -103,8 +103,8 @@ func (s *Scheduler) createActivateWorkflow(
 				notifyOwner(wf, err)
 				for orchardID, status := range scheduleStatus {
 					if status == Activated.ToString() {
-						err = client.Cancel(orchardID) // cancel activated workflows
-						if err != nil {
+						// cancel activated workflows
+						if err := client.Cancel(orchardID); err != nil {
 							fmt.Printf("[error] error canceling workflow: %s\n", err)
 							scheduleStatus[orchardID] = CancelFailed.ToString()
 						}

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -124,18 +124,17 @@ func (s *Scheduler) createActivateWorkflow(
 	if err != nil {
 		fmt.Printf("[error] error creating workflow: %s\n", err)
 		notifyOwner(wf, err)
-		statuses = s.deleteWorkflows(client, createdIDs, statuses)
-	} else {
-		for _, createdID := range createdIDs {
-			err = client.Activate(createdID)
-			if err != nil {
-				fmt.Printf("[error] error activating workflow: %s\n", err)
-				notifyOwner(wf, err)
-				statuses = s.cancelWorkflows(client, statuses)
-			} else {
-				statuses[createdID] = Activated.ToString()
-			}
+		return s.deleteWorkflows(client, createdIDs, statuses)
+	}
+	for _, createdID := range createdIDs {
+		err = client.Activate(createdID)
+		if err != nil {
+			fmt.Printf("[error] error activating workflow: %s\n", err)
+			notifyOwner(wf, err)
+			return s.cancelWorkflows(client, statuses)
 		}
+		statuses[createdID] = Activated.ToString()
+
 	}
 	return statuses
 }

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -92,8 +92,9 @@ func (s *Scheduler) createActivateWorkflow(
 			if err := client.Delete(createdID); err != nil {
 				fmt.Printf("[error] error deleting workflow: %s\n", err)
 				scheduleStatus[createdID] = DeleteFailed.ToString()
+			} else {
+				scheduleStatus[createdID] = Deleted.ToString()
 			}
-			scheduleStatus[createdID] = Deleted.ToString()
 		}
 	} else {
 		for _, createdID := range createdIDs {
@@ -107,8 +108,9 @@ func (s *Scheduler) createActivateWorkflow(
 						if err := client.Cancel(orchardID); err != nil {
 							fmt.Printf("[error] error canceling workflow: %s\n", err)
 							scheduleStatus[orchardID] = CancelFailed.ToString()
+						} else {
+							scheduleStatus[orchardID] = Canceled.ToString()
 						}
-						scheduleStatus[orchardID] = Canceled.ToString()
 					}
 				}
 			} else {

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -126,6 +126,7 @@ func (s *Scheduler) createActivateWorkflow(
 		notifyOwner(wf, err)
 		return s.deleteWorkflows(client, createdIDs, statuses)
 	}
+
 	for _, createdID := range createdIDs {
 		err = client.Activate(createdID)
 		if err != nil {
@@ -134,7 +135,6 @@ func (s *Scheduler) createActivateWorkflow(
 			return s.cancelWorkflows(client, statuses)
 		}
 		statuses[createdID] = Activated.ToString()
-
 	}
 	return statuses
 }


### PR DESCRIPTION
the change to support multi-workflows returned from orchard payload generation, this is tested successfully in QA for both old and new `--array` spade generate command