### PR TITLE
crop SNS message based on max size limit

### DIFF
--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -22,7 +22,7 @@ import (
 )
 
 // https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
-const SNSMaxMessageSizeBytes int = 262144
+const SNSMessageMaxBytes int = 262144
 
 type ScheduleStatus int
 
@@ -219,7 +219,7 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 		log.Println("[error] error initiating SNS client")
 	}
 
-	croppedErrMsg := topBytes(errMsg, SNSMaxMessageSizeBytes)
+	croppedErrMsg := topBytes(errMsg, SNSMessageMaxBytes)
 	input := &sns.PublishInput{
 		Message:  &croppedErrMsg,
 		TopicArn: wf.Owner,

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -219,9 +219,9 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 		log.Println("[error] error initiating SNS client")
 	}
 
-	cleanErrMsg := topBytes(errMsg, SNSMaxMessageSizeBytes)
+	croppedErrMsg := topBytes(errMsg, SNSMaxMessageSizeBytes)
 	input := &sns.PublishInput{
-		Message:  &cleanErrMsg,
+		Message:  &croppedErrMsg,
 		TopicArn: wf.Owner,
 	}
 

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -219,7 +219,7 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 		log.Println("[error] error initiating SNS client")
 	}
 
-	croppedErrMsg := topBytes(errMsg, SNSMessageMaxBytes)
+	croppedErrMsg := truncate(errMsg, SNSMessageMaxBytes)
 	input := &sns.PublishInput{
 		Message:  &croppedErrMsg,
 		TopicArn: wf.Owner,
@@ -271,7 +271,7 @@ func addInterval(someTime time.Time, every model.Every) time.Time {
 	panic(fmt.Sprintf("Every unit '%s' not recognized", every.Unit))
 }
 
-func topBytes(str string, bytes int) string {
+func truncate(str string, bytes int) string {
 	slice := []byte(str)
 	if len(slice) <= bytes {
 		return str


### PR DESCRIPTION
We encounter SNS message too big error in Sprinkler, example:

```
operation error SNS: Publish, https response error StatusCode: 400, RequestID: ed1e8d24-322b-53f6-abdb-d071e33a34d4, InvalidParameter: Invalid parameter: Message too long
```
