### PR TITLE
support stagger start time when multiple workflows from orchard runner

### DIFF
--- a/database/schema.go
+++ b/database/schema.go
@@ -17,6 +17,7 @@ var Tables = []interface{}{
 	&table.Workflow{},
 	&table.ScheduledWorkflow{},
 	&table.WorkflowSchedulerLock{},
+	&table.WorkflowActivatorLock{},
 }
 
 var owner = os.Getenv("OWNER_SNS")

--- a/database/table/tables.go
+++ b/database/table/tables.go
@@ -14,14 +14,15 @@ import (
 
 type Workflow struct {
 	gorm.Model
-	Name        string      `gorm:"type:varchar(256);not null;index:workflows_name,unique"`
-	Artifact    string      `gorm:"type:varchar(2048);not null"`
-	Command     string      `gorm:"type:text;not null"`
-	Every       model.Every `gorm:"type:varchar(64);not null"`
-	NextRuntime time.Time   `gorm:"not null"`
-	Backfill    bool        `gorm:"not null"`
-	Owner       *string     `gorm:"type:varchar(2048)"`
-	IsActive    bool        `gorm:"not null"`
+	Name                string      `gorm:"type:varchar(256);not null;index:workflows_name,unique"`
+	Artifact            string      `gorm:"type:varchar(2048);not null"`
+	Command             string      `gorm:"type:text;not null"`
+	Every               model.Every `gorm:"type:varchar(64);not null"`
+	NextRuntime         time.Time   `gorm:"not null"`
+	Backfill            bool        `gorm:"not null"`
+	Owner               *string     `gorm:"type:varchar(2048)"`
+	IsActive            bool        `gorm:"not null"`
+	StaggerStartMinutes uint        `gorm:"default:0"`
 
 	ScheduledWorkflows []ScheduledWorkflow
 }
@@ -39,4 +40,10 @@ type WorkflowSchedulerLock struct {
 	WorkflowID uint      `gorm:"primaryKey"`
 	Token      string    `gorm:"type:varchar(64);not null"`
 	LockTime   time.Time `gorm:"not null"`
+}
+
+type WorkflowActivatorLock struct {
+	ScheduledID uint      `gorm:"primaryKey"`
+	Token       string    `gorm:"type:varchar(64);not null"`
+	LockTime    time.Time `gorm:"not null"`
 }

--- a/database/table/tables.go
+++ b/database/table/tables.go
@@ -14,15 +14,15 @@ import (
 
 type Workflow struct {
 	gorm.Model
-	Name                string      `gorm:"type:varchar(256);not null;index:workflows_name,unique"`
-	Artifact            string      `gorm:"type:varchar(2048);not null"`
-	Command             string      `gorm:"type:text;not null"`
-	Every               model.Every `gorm:"type:varchar(64);not null"`
-	NextRuntime         time.Time   `gorm:"not null"`
-	Backfill            bool        `gorm:"not null"`
-	Owner               *string     `gorm:"type:varchar(2048)"`
-	IsActive            bool        `gorm:"not null"`
-	StaggerStartMinutes uint        `gorm:"default:0"`
+	Name                 string      `gorm:"type:varchar(256);not null;index:workflows_name,unique"`
+	Artifact             string      `gorm:"type:varchar(2048);not null"`
+	Command              string      `gorm:"type:text;not null"`
+	Every                model.Every `gorm:"type:varchar(64);not null"`
+	NextRuntime          time.Time   `gorm:"not null"`
+	Backfill             bool        `gorm:"not null"`
+	Owner                *string     `gorm:"type:varchar(2048)"`
+	IsActive             bool        `gorm:"not null"`
+	ScheduleDelayMinutes uint        `gorm:"default:0"`
 
 	ScheduledWorkflows []ScheduledWorkflow
 }

--- a/orchard/orchard_client.go
+++ b/orchard/orchard_client.go
@@ -107,15 +107,15 @@ func (c OrchardRestClient) Delete(orchardID string) error {
 type FakeOrchardClient struct {
 }
 
-func (c FakeOrchardClient) Create(wf table.Workflow) (string, error) {
+func (c FakeOrchardClient) Create(wf table.Workflow) ([]string, error) {
 	runner := OrchardStdoutRunner{}
 	results, err := runner.Generate(wf.Artifact, wf.Command)
 	if err != nil {
-		return "", err
+		return []string{""}, err
 	}
 	log.Println("generating workflow", results)
 	time.Sleep(1 * time.Second)
-	return fmt.Sprintf("wf-%s", uuid.New().String()), nil
+	return []string{fmt.Sprintf("wf-%s", uuid.New().String())}, nil
 }
 
 func (c FakeOrchardClient) Activate(wfID string) error {

--- a/service/control.go
+++ b/service/control.go
@@ -28,14 +28,15 @@ type Control struct {
 }
 
 type postWorkflowReq struct {
-	Name        string    `json:"name" binding:"required"`
-	Artifact    string    `json:"artifact" binding:"required"`
-	Command     string    `json:"command" binding:"required"`
-	Every       string    `json:"every" binding:"required"`
-	NextRuntime time.Time `json:"nextRuntime" binding:"required"`
-	Backfill    bool      `json:"backfill"` // default false if absent
-	Owner       *string   `json:"owner"`
-	IsActive    bool      `json:"isActive"` // default false if absent
+	Name                string    `json:"name" binding:"required"`
+	Artifact            string    `json:"artifact" binding:"required"`
+	Command             string    `json:"command" binding:"required"`
+	Every               string    `json:"every" binding:"required"`
+	NextRuntime         time.Time `json:"nextRuntime" binding:"required"`
+	Backfill            bool      `json:"backfill"` // default false if absent
+	Owner               *string   `json:"owner"`
+	IsActive            bool      `json:"isActive"` // default false if absent
+	StaggerStartMinutes uint      `json:"staggerStartMinutes"`
 }
 
 type deleteWorkflowReq struct {
@@ -68,20 +69,21 @@ func (ctrl *Control) putWorkflow(c *gin.Context) {
 	}
 
 	wf := table.Workflow{
-		Name:        body.Name,
-		Artifact:    body.Artifact,
-		Command:     body.Command,
-		Every:       every,
-		NextRuntime: body.NextRuntime,
-		Backfill:    body.Backfill,
-		Owner:       body.Owner,
-		IsActive:    body.IsActive,
+		Name:                body.Name,
+		Artifact:            body.Artifact,
+		Command:             body.Command,
+		Every:               every,
+		NextRuntime:         body.NextRuntime,
+		Backfill:            body.Backfill,
+		Owner:               body.Owner,
+		IsActive:            body.IsActive,
+		StaggerStartMinutes: body.StaggerStartMinutes,
 	}
 	// upsert workflow
 	ctrl.db.Clauses(
 		clause.OnConflict{
 			Columns:   []clause.Column{{Name: "name"}},
-			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "artifact", "command", "every", "next_runtime", "backfill", "owner", "is_active"}),
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "artifact", "command", "every", "next_runtime", "backfill", "owner", "is_active", "stagger_start_minutes"}),
 		}).Create(&wf)
 	ctrl.db.Unscoped().Model(&wf).Update("deleted_at", nil)
 	c.JSON(http.StatusOK, "OK")

--- a/service/control.go
+++ b/service/control.go
@@ -28,15 +28,15 @@ type Control struct {
 }
 
 type postWorkflowReq struct {
-	Name                string    `json:"name" binding:"required"`
-	Artifact            string    `json:"artifact" binding:"required"`
-	Command             string    `json:"command" binding:"required"`
-	Every               string    `json:"every" binding:"required"`
-	NextRuntime         time.Time `json:"nextRuntime" binding:"required"`
-	Backfill            bool      `json:"backfill"` // default false if absent
-	Owner               *string   `json:"owner"`
-	IsActive            bool      `json:"isActive"` // default false if absent
-	StaggerStartMinutes uint      `json:"staggerStartMinutes"`
+	Name                 string    `json:"name" binding:"required"`
+	Artifact             string    `json:"artifact" binding:"required"`
+	Command              string    `json:"command" binding:"required"`
+	Every                string    `json:"every" binding:"required"`
+	NextRuntime          time.Time `json:"nextRuntime" binding:"required"`
+	Backfill             bool      `json:"backfill"` // default false if absent
+	Owner                *string   `json:"owner"`
+	IsActive             bool      `json:"isActive"` // default false if absent
+	ScheduleDelayMinutes uint      `json:"scheduleDelayMinutes"`
 }
 
 type deleteWorkflowReq struct {
@@ -69,15 +69,15 @@ func (ctrl *Control) putWorkflow(c *gin.Context) {
 	}
 
 	wf := table.Workflow{
-		Name:                body.Name,
-		Artifact:            body.Artifact,
-		Command:             body.Command,
-		Every:               every,
-		NextRuntime:         body.NextRuntime,
-		Backfill:            body.Backfill,
-		Owner:               body.Owner,
-		IsActive:            body.IsActive,
-		StaggerStartMinutes: body.StaggerStartMinutes,
+		Name:                 body.Name,
+		Artifact:             body.Artifact,
+		Command:              body.Command,
+		Every:                every,
+		NextRuntime:          body.NextRuntime,
+		Backfill:             body.Backfill,
+		Owner:                body.Owner,
+		IsActive:             body.IsActive,
+		ScheduleDelayMinutes: body.ScheduleDelayMinutes,
 	}
 	// upsert workflow
 	ctrl.db.Clauses(

--- a/service/control.go
+++ b/service/control.go
@@ -83,7 +83,7 @@ func (ctrl *Control) putWorkflow(c *gin.Context) {
 	ctrl.db.Clauses(
 		clause.OnConflict{
 			Columns:   []clause.Column{{Name: "name"}},
-			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "artifact", "command", "every", "next_runtime", "backfill", "owner", "is_active", "stagger_start_minutes"}),
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "artifact", "command", "every", "next_runtime", "backfill", "owner", "is_active", "schedule_delay_minutes"}),
 		}).Create(&wf)
 	ctrl.db.Unscoped().Model(&wf).Update("deleted_at", nil)
 	c.JSON(http.StatusOK, "OK")

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -199,9 +199,9 @@ func (s *Scheduler) lockAndCreate(db *gorm.DB, wf table.Workflow) {
 
 	scheduleStatus := s.createWorkflow(client, wf)
 
-	var staggerStartMinutes uint = 0
-	if wf.StaggerStartMinutes != 0 {
-		staggerStartMinutes = wf.StaggerStartMinutes
+	var scheduleDelayMinutes uint = 0
+	if wf.ScheduleDelayMinutes != 0 {
+		scheduleDelayMinutes = wf.ScheduleDelayMinutes
 	}
 
 	// add to scheduled and update the next run time
@@ -217,7 +217,7 @@ func (s *Scheduler) lockAndCreate(db *gorm.DB, wf table.Workflow) {
 			}).Error; err != nil {
 				return err
 			}
-			startTime = startTime.Add(time.Duration(staggerStartMinutes) * time.Minute)
+			startTime = startTime.Add(time.Duration(scheduleDelayMinutes) * time.Minute)
 		}
 
 		fmt.Println(wf.Every)

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -160,9 +160,7 @@ func (s *Scheduler) activateWorkflow(
 	if err := client.Activate(swf.OrchardID); err != nil {
 		fmt.Printf("[error] error activating workflow: %s\n", err)
 		notifyOwner(wf, err)
-		statuses := make(map[string]string)
-		statuses[swf.OrchardID] = swf.Status
-		return s.deleteWorkflows(client, []string{swf.OrchardID}, statuses)[swf.OrchardID]
+		return swf.Status
 	}
 	return Activated.ToString()
 }

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -199,11 +199,6 @@ func (s *Scheduler) lockAndCreate(db *gorm.DB, wf table.Workflow) {
 
 	scheduleStatus := s.createWorkflow(client, wf)
 
-	var scheduleDelayMinutes uint = 0
-	if wf.ScheduleDelayMinutes != 0 {
-		scheduleDelayMinutes = wf.ScheduleDelayMinutes
-	}
-
 	// add to scheduled and update the next run time
 	db.Transaction(func(tx *gorm.DB) error {
 		startTime := time.Now()
@@ -217,7 +212,7 @@ func (s *Scheduler) lockAndCreate(db *gorm.DB, wf table.Workflow) {
 			}).Error; err != nil {
 				return err
 			}
-			startTime = startTime.Add(time.Duration(scheduleDelayMinutes) * time.Minute)
+			startTime = startTime.Add(time.Duration(wf.ScheduleDelayMinutes) * time.Minute)
 		}
 
 		fmt.Println(wf.Every)


### PR DESCRIPTION
when orchard runner returns multiple workflows, schedule option to `StaggerStartMinutes` allow activating each orchard workflow with a gap of the specified minutes.  

in scheduler, decoupled the original create and activate from a single method to 2.  create will add stagger start minutes to each of next workflow as the `start_time`.  This data goes to the `scheduled_workflows` table.  A new decoupled method activate workflow will follow the time tick, and activate upon the start_time.  

The schema is updated.  And the ws payload is added with an optional field `StaggerStartMinutes`.