### PR TITLE
automatic deletion of expired scheduled_workflow rows

### DIFF
--- a/cmd/scheduler.go
+++ b/cmd/scheduler.go
@@ -14,21 +14,22 @@ import (
 )
 
 type SchedulerCmdOpt struct {
-	Interval    time.Duration
-	LockTimeout time.Duration
-
-	OrchardAddress    string
-	OrchardAPIKeyName string
-	OrchardAPIKey     string
+	Interval                 time.Duration
+	LockTimeout              time.Duration
+	OrchardAddress           string
+	OrchardAPIKeyName        string
+	OrchardAPIKey            string
+	ScheduledWorkflowTimeout time.Duration
 }
 
 func getSchedulerCmdOpt() SchedulerCmdOpt {
 	return SchedulerCmdOpt{
-		Interval:          viper.GetDuration("scheduler.interval"),
-		OrchardAddress:    viper.GetString("scheduler.orchard.address"),
-		OrchardAPIKeyName: viper.GetString("scheduler.orchard.apiKeyName"),
-		OrchardAPIKey:     viper.GetString("scheduler.orchard.apiKey"),
-		LockTimeout:       viper.GetDuration("scheduler.lockTimeout"),
+		Interval:                 viper.GetDuration("scheduler.interval"),
+		LockTimeout:              viper.GetDuration("scheduler.lockTimeout"),
+		OrchardAddress:           viper.GetString("scheduler.orchard.address"),
+		OrchardAPIKeyName:        viper.GetString("scheduler.orchard.apiKeyName"),
+		OrchardAPIKey:            viper.GetString("scheduler.orchard.apiKey"),
+		ScheduledWorkflowTimeout: viper.GetDuration("scheduler.scheduledWorkflowTimeout"),
 	}
 }
 
@@ -93,4 +94,14 @@ func init() {
 		"Workflow schedule and activation lock TTL",
 	)
 	viper.BindPFlag("scheduler.lockTimeout", schedulerCmd.Flags().Lookup("lockTimeout"))
+
+	schedulerCmd.Flags().Duration(
+		"scheduledWorkflowTimeout",
+		time.Hour*24*30,
+		"scheduled_workflow entries are considered expired if updated_at older than this duration",
+	)
+	viper.BindPFlag(
+		"scheduler.scheduledWorkflowTimeout",
+		schedulerCmd.Flags().Lookup("scheduledWorkflowTimeout"),
+	)
 }

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -54,12 +54,13 @@ func (s ScheduleStatus) ToString() string {
 }
 
 type Scheduler struct {
-	Interval          time.Duration
-	LockTimeout       time.Duration
-	MaxSize           uint
-	OrchardHost       string
-	OrchardAPIKeyName string
-	OrchardAPIKey     string
+	Interval                 time.Duration
+	LockTimeout              time.Duration
+	MaxSize                  uint
+	OrchardHost              string
+	OrchardAPIKeyName        string
+	OrchardAPIKey            string
+	ScheduledWorkflowTimeout time.Duration
 }
 
 func (s *Scheduler) Start() {
@@ -83,6 +84,14 @@ func (s *Scheduler) deleteExpiredLocks(db *gorm.DB) {
 	db.Model(&table.WorkflowSchedulerLock{}).
 		Where("lock_time < ?", expiryTime).
 		Delete(&table.WorkflowSchedulerLock{})
+}
+
+func (s *Scheduler) deleteExpiredScheduledWorkflows(db *gorm.DB) {
+	expiryTime := time.Now().Add(-s.ScheduledWorkflowTimeout)
+
+	db.Model(&table.ScheduledWorkflow{}).
+		Where("updated_at < ?", expiryTime).
+		Delete(&table.ScheduledWorkflow{})
 }
 
 func (s *Scheduler) scheduleWorkflows(db *gorm.DB) {


### PR DESCRIPTION
Allows setting an expiration for entries in the scheduled_workflows table via config. Workflows with an `updated_at` value older than now - `ScheduledWorkflowTimeout` are deleted on `tick`. 