### PR TITLE
Add GET endpoint to Sprinkler workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Start control service on a new tab, to later post a Sprinkler json workflow
 go run . service control --config .sprinkler.yaml 
 ```
 
-Post to `http://localhost:8080/v1/workflow` a Sprinkler workflow, example payload from [ExampleWorkflow.scala](https://github.com/salesforce/spade/blob/main/spade-examples/src/main/scala/com/salesforce/mce/spade/examples/ExampleWorkflow.scala)
+Put to `http://localhost:8080/v1/workflow` a Sprinkler workflow, example payload from [ExampleWorkflow.scala](https://github.com/salesforce/spade/blob/main/spade-examples/src/main/scala/com/salesforce/mce/spade/examples/ExampleWorkflow.scala)
 ```
 {
     "name": "test-workflow",
     "artifact": "s3://sprinkler-salesforce-bucket/jars/test/spade-example.jar",
     "command":  "[\"java\", \"-cp\", \"spade-example.jar\", \"com.salesforce.mce.spade.examples.ExampleWorkflow\", \"generate\", \"--compact\"]",
     "every": "60.minute",
-    "nextRuntime": "2023-03-22T21:00:00Z",
+    "nextRuntime": "2024-08-22T21:00:00Z",
     "backfill": false,
     "owner": "arn:aws:sns:us-east-2:444455556666:MyTopic",
     "isActive": true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,10 +18,10 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "sprinkler",
-	Short: "Workflow scheculer built for orchard",
+	Short: "Workflow scheduler built for orchard",
 	Long: `Sprinkler CLI provides all the necessary commands to setup the database, test
 orchard servers and other services to run and manage workflows for orchard
-orchastration server`,
+orchestration server`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Add GET endpoint to Sprinkler workflows. To facilitate support use cases with the GET response payload to be edited for new PUT requests.

Fix typos in service/control.go and README.md