### PR TITLE
Feat: support workflow name template in the SNS subject

### DIFF
--- a/.sprinkler.yaml
+++ b/.sprinkler.yaml
@@ -38,6 +38,11 @@ cleanup:
 # SNS notification configuration
 sns:
   # Subject for workflow failure notifications
+  # Supports template placeholder {workflow_name} to include the workflow name
+  # Examples:
+  #   - "Workflow Schedule Failure" (default, no workflow name)
+  #   - "[{workflow_name}] Workflow Schedule Failure" (with workflow name in brackets)
+  #   - "{workflow_name}: Schedule Failure" (workflow name as prefix)
   subject: "Workflow Schedule Failure"
 
 # configs for static credentials or role arn to assume

--- a/.sprinkler.yaml
+++ b/.sprinkler.yaml
@@ -37,21 +37,17 @@ cleanup:
 
 # SNS notification configuration
 sns:
-  # Subject for workflow failure notifications
-  # Supports template placeholder {workflow_name} to include the workflow name
+  # Subject for workflow failure notifications using Go text/template syntax
+  # Available data: .WorkflowName (the full workflow name)
+  # Available functions: regexExtract <pattern> <text> (extracts first regex match)
+  #
   # Examples:
-  #   - "Workflow Schedule Failure" (default, no workflow name)
-  #   - "[{workflow_name}] Workflow Schedule Failure" (with workflow name in brackets)
-  #   - "{workflow_name}: Schedule Failure" (workflow name as prefix)
+  #   - "Workflow Schedule Failure" (no workflow name)
+  #   - "[{{.WorkflowName}}] Workflow Schedule Failure" (full workflow name in brackets)
+  #   - "{{.WorkflowName}}: Schedule Failure" (workflow name as prefix)
+  #   - "[{{regexExtract `[^.]+$` .WorkflowName}}] Failure" (extract "text" from "com.abc.text")
+  #   - "[{{regexExtract `\.([^.]+)$` .WorkflowName}}] Failure" (extract using capture group)
   subject: "Workflow Schedule Failure"
-
-  # Optional regex pattern to extract a simpler name from the full workflow name
-  # The first match found will be used as the workflow name in the subject
-  # Examples:
-  #   - "[^.]+$" extracts "text" from "com.abc.text" (everything after the last dot)
-  #   - "\.([^.]+)$" extracts "text" from "com.abc.text" (capture group after last dot)
-  #   - "^[^.]+\.(.+)" extracts "abc.text" from "com.abc.text" (everything after first dot)
-  # workflowNameRegex: "[^.]+$"
 
 # configs for static credentials or role arn to assume
 # aws:

--- a/.sprinkler.yaml
+++ b/.sprinkler.yaml
@@ -39,14 +39,18 @@ cleanup:
 sns:
   # Subject for workflow failure notifications using Go text/template syntax
   # Available data: .WorkflowName (the full workflow name)
-  # Available functions: regexExtract <pattern> <text> (extracts first regex match)
+  # Available functions:
+  #   - regexExtract <pattern> <text> (extracts first regex match)
+  #   - stripPrefix <prefix> <text> (removes prefix from text)
+  #   - stripSuffix <suffix> <text> (removes suffix from text)
   #
   # Examples:
   #   - "Workflow Schedule Failure" (no workflow name)
   #   - "[{{.WorkflowName}}] Workflow Schedule Failure" (full workflow name in brackets)
   #   - "{{.WorkflowName}}: Schedule Failure" (workflow name as prefix)
   #   - "[{{regexExtract `[^.]+$` .WorkflowName}}] Failure" (extract "text" from "com.abc.text")
-  #   - "[{{regexExtract `\.([^.]+)$` .WorkflowName}}] Failure" (extract using capture group)
+  #   - "[{{stripPrefix `com.abc.` .WorkflowName}}] Failure" (strip "com.abc." prefix)
+  #   - "[{{stripSuffix `.workflow` .WorkflowName}}] Failure" (strip ".workflow" suffix)
   subject: "Workflow Schedule Failure"
 
 # configs for static credentials or role arn to assume

--- a/.sprinkler.yaml
+++ b/.sprinkler.yaml
@@ -45,6 +45,14 @@ sns:
   #   - "{workflow_name}: Schedule Failure" (workflow name as prefix)
   subject: "Workflow Schedule Failure"
 
+  # Optional regex pattern to extract a simpler name from the full workflow name
+  # The first match found will be used as the workflow name in the subject
+  # Examples:
+  #   - "[^.]+$" extracts "text" from "com.abc.text" (everything after the last dot)
+  #   - "\.([^.]+)$" extracts "text" from "com.abc.text" (capture group after last dot)
+  #   - "^[^.]+\.(.+)" extracts "abc.text" from "com.abc.text" (everything after first dot)
+  # workflowNameRegex: "[^.]+$"
+
 # configs for static credentials or role arn to assume
 # aws:
 #   clientRegion: "changeme"

--- a/common/config_keys.go
+++ b/common/config_keys.go
@@ -6,11 +6,10 @@
 package common
 
 const (
-	DBConfigHost           string = "db.host"
-	DBConfigUser                  = "db.user"
-	DBConfigPassword              = "db.password"
-	DBConfigDBName                = "db.dbname"
-	DBConfigSSLMode               = "db.sslmode"
-	SNSConfigSubject              = "sns.subject"
-	SNSConfigWorkflowNameRegex    = "sns.workflowNameRegex"
+	DBConfigHost     string = "db.host"
+	DBConfigUser            = "db.user"
+	DBConfigPassword        = "db.password"
+	DBConfigDBName          = "db.dbname"
+	DBConfigSSLMode         = "db.sslmode"
+	SNSConfigSubject        = "sns.subject"
 )

--- a/common/config_keys.go
+++ b/common/config_keys.go
@@ -6,10 +6,11 @@
 package common
 
 const (
-	DBConfigHost     string = "db.host"
-	DBConfigUser            = "db.user"
-	DBConfigPassword        = "db.password"
-	DBConfigDBName          = "db.dbname"
-	DBConfigSSLMode         = "db.sslmode"
-	SNSConfigSubject        = "sns.subject"
+	DBConfigHost           string = "db.host"
+	DBConfigUser                  = "db.user"
+	DBConfigPassword              = "db.password"
+	DBConfigDBName                = "db.dbname"
+	DBConfigSSLMode               = "db.sslmode"
+	SNSConfigSubject              = "sns.subject"
+	SNSConfigWorkflowNameRegex    = "sns.workflowNameRegex"
 )

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -6,11 +6,13 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
@@ -294,22 +296,41 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 		log.Println("[error] error initiating SNS client")
 	}
 
-	subject := viper.GetString(common.SNSConfigSubject)
+	subjectTemplate := viper.GetString(common.SNSConfigSubject)
+	var subject string
 
-	// Extract workflow name using regex if configured
-	workflowName := wf.Name
-	regexPattern := viper.GetString(common.SNSConfigWorkflowNameRegex)
-	if regexPattern != "" {
-		re, err := regexp.Compile(regexPattern)
-		if err != nil {
-			log.Printf("[warning] invalid sns.workflowNameRegex pattern %q: %v\n", regexPattern, err)
-		} else if match := re.FindString(wf.Name); match != "" {
-			workflowName = match
-		}
+	// Create template with custom functions
+	funcMap := template.FuncMap{
+		"regexExtract": func(pattern, text string) string {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				log.Printf("[warning] invalid regex pattern %q: %v\n", pattern, err)
+				return text
+			}
+			if match := re.FindString(text); match != "" {
+				return match
+			}
+			return text
+		},
 	}
 
-	// Replace {workflow_name} placeholder with extracted workflow name
-	subject = strings.ReplaceAll(subject, "{workflow_name}", workflowName)
+	// Execute template
+	tmpl, err := template.New("subject").Funcs(funcMap).Parse(subjectTemplate)
+	if err != nil {
+		log.Printf("[warning] invalid SNS subject template %q: %v\n", subjectTemplate, err)
+		subject = subjectTemplate // fallback to raw template
+	} else {
+		var buf bytes.Buffer
+		data := map[string]interface{}{
+			"WorkflowName": wf.Name,
+		}
+		if err := tmpl.Execute(&buf, data); err != nil {
+			log.Printf("[warning] error executing SNS subject template: %v\n", err)
+			subject = subjectTemplate // fallback to raw template
+		} else {
+			subject = buf.String()
+		}
+	}
 
 	// If subject exceeds 100 characters, truncate at the last whitespace before position 100
 	messageBody := errMsg

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
@@ -293,6 +294,9 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 	}
 
 	subject := viper.GetString(common.SNSConfigSubject)
+
+	// Replace {workflow_name} placeholder with actual workflow name
+	subject = strings.ReplaceAll(subject, "{workflow_name}", wf.Name)
 
 	if len(subject) > 100 {
 		subject = subject[:100]

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -312,6 +312,12 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 			}
 			return text
 		},
+		"stripPrefix": func(prefix, text string) string {
+			return strings.TrimPrefix(text, prefix)
+		},
+		"stripSuffix": func(suffix, text string) string {
+			return strings.TrimSuffix(text, suffix)
+		},
 	}
 
 	// Execute template

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -295,8 +296,20 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 
 	subject := viper.GetString(common.SNSConfigSubject)
 
-	// Replace {workflow_name} placeholder with actual workflow name
-	subject = strings.ReplaceAll(subject, "{workflow_name}", wf.Name)
+	// Extract workflow name using regex if configured
+	workflowName := wf.Name
+	regexPattern := viper.GetString(common.SNSConfigWorkflowNameRegex)
+	if regexPattern != "" {
+		re, err := regexp.Compile(regexPattern)
+		if err != nil {
+			log.Printf("[warning] invalid sns.workflowNameRegex pattern %q: %v\n", regexPattern, err)
+		} else if match := re.FindString(wf.Name); match != "" {
+			workflowName = match
+		}
+	}
+
+	// Replace {workflow_name} placeholder with extracted workflow name
+	subject = strings.ReplaceAll(subject, "{workflow_name}", workflowName)
 
 	// If subject exceeds 100 characters, truncate at the last whitespace before position 100
 	messageBody := errMsg

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -298,11 +298,21 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 	// Replace {workflow_name} placeholder with actual workflow name
 	subject = strings.ReplaceAll(subject, "{workflow_name}", wf.Name)
 
+	// If subject exceeds 100 characters, truncate at the last whitespace before position 100
+	messageBody := errMsg
 	if len(subject) > 100 {
-		subject = subject[:100]
+		// Find the last whitespace before position 100
+		truncatePos := strings.LastIndexAny(subject[:100], " \t\n")
+		if truncatePos == -1 {
+			// No whitespace found, truncate at position 100
+			truncatePos = 100
+		}
+		exceededPortion := subject[truncatePos:]
+		messageBody = fmt.Sprintf("Subject (truncated): %s\n\n%s", strings.TrimSpace(exceededPortion), errMsg)
+		subject = strings.TrimSpace(subject[:truncatePos])
 	}
 
-	croppedErrMsg := truncate(errMsg, SNSMessageMaxBytes)
+	croppedErrMsg := truncate(messageBody, SNSMessageMaxBytes)
 	input := &sns.PublishInput{
 		Message:  &croppedErrMsg,
 		Subject:  &subject,

--- a/service/scheduler.go
+++ b/service/scheduler.go
@@ -307,9 +307,13 @@ func notifyOwner(wf table.Workflow, orchardErr error) {
 			// No whitespace found, truncate at position 100
 			truncatePos = 100
 		}
-		exceededPortion := subject[truncatePos:]
-		messageBody = fmt.Sprintf("Subject (truncated): %s\n\n%s", strings.TrimSpace(exceededPortion), errMsg)
+		exceededPortion := strings.TrimSpace(subject[truncatePos:])
 		subject = strings.TrimSpace(subject[:truncatePos])
+
+		// Only add truncation message if there's actual content that was truncated
+		if exceededPortion != "" {
+			messageBody = fmt.Sprintf("Subject (truncated): %s\n\n%s", exceededPortion, errMsg)
+		}
 	}
 
 	croppedErrMsg := truncate(messageBody, SNSMessageMaxBytes)


### PR DESCRIPTION
The purpose of this PR was to address the issue of the SNS message body not being indexed in Slack, which made it unsearchable. Adding the workflow name to the SNS subject will enhance searchability.